### PR TITLE
Update lab-3-notebook.ipynb

### DIFF
--- a/lab3-dictionaries-pandas-series/lab-3-notebook.ipynb
+++ b/lab3-dictionaries-pandas-series/lab-3-notebook.ipynb
@@ -26,7 +26,7 @@
     "* By using if-elif-else statements we can realize conditional flow in a program. \n",
     "* If an elif take a parameter that is tested for truth. The parameter can be a boolean (`True` or `False`), or any other data type. \n",
     "    * For numerical data types, 0 and None evaluates to false, everything else to true.\n",
-    "    * For lists, strings, dictionaries, and empty container evaluates to false.\n",
+    "    * For lists, strings, dictionaries, an empty container evaluates to false.\n",
     "\n",
     "See the [documentation](https://docs.python.org/3/library/stdtypes.html#truth-value-testing) to understand what is considered true and false."
    ]


### PR DESCRIPTION
"For lists, strings, dictionaries, and empty container evaluates to false." needs to read an not and?

Just a typo, I created this request in case I find others in this lab